### PR TITLE
Fix incorrect entity key for link entities.

### DIFF
--- a/docs/src/docs/decorators/link.mdx
+++ b/docs/src/docs/decorators/link.mdx
@@ -17,7 +17,8 @@ you'll see an example of adding and removing links at the bottom of this page.
   addLink(
     state: State,
     stateHandler: StateHandler,
-    attributes?: LinkAttributes
+    attributes?: LinkAttributes,
+    customLinkKey?: string
   ) => void
 ```
 

--- a/packages/core/src/utilities/decorator/addLink.ts
+++ b/packages/core/src/utilities/decorator/addLink.ts
@@ -7,11 +7,12 @@ import type { LinkAttributes, State, StateHandler } from '../../types';
 const addLink = (
   state: State,
   stateHandler: StateHandler,
-  attributes?: LinkAttributes
+  attributes?: LinkAttributes,
+  customLinkKey?: string
 ) => {
   const currentContent = state.getCurrentContent();
   const contentStateWithEntity = currentContent.createEntity(
-    'link',
+    customLinkKey ?? 'link',
     'IMMUTABLE',
     attributes
   );

--- a/packages/core/src/utilities/entity/isLink.ts
+++ b/packages/core/src/utilities/entity/isLink.ts
@@ -9,7 +9,7 @@ const isLink = (editorState: State, customLinkKey?: string) => {
   if (entityKey) {
     const entity = contentState.getEntity(entityKey);
     const entityType = entity.getType();
-    return entityType === (customLinkKey ?? 'LINK');
+    return entityType === (customLinkKey ?? 'link');
   }
   return false;
 };


### PR DESCRIPTION
Fix incorrect entity key for link entities. Add parameter to `addLink` to allow for custom link keys.

Issue: #13 