### PR TITLE
added 'toggle code block' and 'isCodeBlock' in the blocks utilities, …

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contenido",
-  "version": "1.2.13",
+  "version": "1.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contenido",
-      "version": "1.2.13",
+      "version": "1.2.15",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2"

--- a/packages/core/src/utilities/block/isCodeBlock.ts
+++ b/packages/core/src/utilities/block/isCodeBlock.ts
@@ -1,0 +1,9 @@
+// Custom Utilities
+import hasBlockTypeOf from '../helper/hasBlockTypeOf';
+
+// Custom Types
+import type { State } from '../../types';
+
+const isCodeBlock = (state: State) => hasBlockTypeOf(state, "code-block");
+
+export default isCodeBlock;

--- a/packages/core/src/utilities/block/toggleCodeBlock.ts
+++ b/packages/core/src/utilities/block/toggleCodeBlock.ts
@@ -1,0 +1,13 @@
+// Custom Utilities
+import toggleBlockType from './toggleBlockType';
+
+// Custom Types
+import type { State, StateHandler } from '../../types';
+
+const toggleCodeBlock = (
+  state: State,
+  stateHandler: StateHandler,
+  customBlockquoteType?: string
+) => toggleBlockType(state, stateHandler, customBlockquoteType || "code-block");
+
+export default toggleCodeBlock;


### PR DESCRIPTION
…to toggle the state to **'pre**',draft js provides 'pre' - code-block in the default render map , so we don't need to add it to custom. 